### PR TITLE
Release

### DIFF
--- a/app/scripts/linux/fill_db.sh
+++ b/app/scripts/linux/fill_db.sh
@@ -1,4 +1,2 @@
 export FLASK_APP=manage
-export FLASK_ENV=development
-export FLASK_DEBUG=1
 flask fill_db

--- a/app/src/modules/crontab/utils.py
+++ b/app/src/modules/crontab/utils.py
@@ -12,6 +12,8 @@ def request_url(url: str, headers: Optional[dict] = None) -> requests.Response:
     :param headers: HTTP headers
     :return: Response object
     """
+    requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'  # Portal SSL error fix
+
     session = requests.Session()
     retry = Retry(connect=3, backoff_factor=0.5)
     adapter = requests.adapters.HTTPAdapter(max_retries=retry)

--- a/app/src/modules/crontab/utils.py
+++ b/app/src/modules/crontab/utils.py
@@ -12,7 +12,8 @@ def request_url(url: str, headers: Optional[dict] = None) -> requests.Response:
     :param headers: HTTP headers
     :return: Response object
     """
-    requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'  # Portal SSL error fix
+    # PORTAL SSL error workaround
+    requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'  # type: ignore
 
     session = requests.Session()
     retry = Retry(connect=3, backoff_factor=0.5)

--- a/app/src/settings.py
+++ b/app/src/settings.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SRC_DIR = BASE_DIR / "src"
 
 env = Env()
-env.read_env(os.path.join(BASE_DIR, 'envs/.env.dev'))
+env.read_env(os.path.join(BASE_DIR, 'envs/.env.prod'))
 
 
 class BaseConfig(object):
@@ -196,4 +196,4 @@ class ProductionConfig(BaseConfig):
     CACHE_DEFAULT_TIMEOUT = 500
 
 
-settings = BaseConfig()
+settings = ProductionConfig()

--- a/app/src/settings.py
+++ b/app/src/settings.py
@@ -14,7 +14,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SRC_DIR = BASE_DIR / "src"
 
 env = Env()
-env.read_env(os.path.join(BASE_DIR, 'envs/.env.prod'))
+env.read_env(os.path.join(BASE_DIR, 'envs/.env.dev'))
 
 
 class BaseConfig(object):
@@ -196,4 +196,4 @@ class ProductionConfig(BaseConfig):
     CACHE_DEFAULT_TIMEOUT = 500
 
 
-settings = ProductionConfig()
+settings = BaseConfig()


### PR DESCRIPTION
fix: portal parsing SSL error 

> HTTPSConnectionPool(host='[portal.com.ge](http://portal.com.ge/)', port=443): Max retries exceeded with url: /georgian/home (Caused by SSLError(SSLError(1, '[SSL: WRONG_SIGNATURE_TYPE] wrong signature type (_ssl.c:1129)'

fix: [https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small](https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small)